### PR TITLE
add workflow for deployment to ebs

### DIFF
--- a/.ebextensions/django.config
+++ b/.ebextensions/django.config
@@ -1,0 +1,3 @@
+option_settings:
+  aws:elasticbeanstalk:container:python:
+    WSGIPath: quatro.wsgi:application

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy master
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Generate deployment package
+        run: zip -r deploy.zip . -x '*.git*'
+
+      - name: Deploy to EB
+        uses: einaregilsson/beanstalk-deploy@v22
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          application_name: ${{ secrets.AWS_EBS_APP_NAME }}
+          environment_name: ${{ secrets.AWS_EBS_APP_ENV }}
+          version_label: ${{ github.event.label.name }}
+          region: ${{secrets.AWS_REGION}}
+          deployment_package: deploy.zip

--- a/quatro/settings.py
+++ b/quatro/settings.py
@@ -24,7 +24,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+if (os.environ.get("DJANGO_DEBUG") == "true"):
+    DEBUG = True
+else:
+    DEBUG = False
 
 ALLOWED_HOSTS = [h for h in os.environ.get("DJANGO_ALLOWED_HOSTS").split(",")]
 


### PR DESCRIPTION
**Summary:**
Added a GitHub workflow to deploy the application to AWS Elastic Beanstalk

Moving forward, assuming the workflow is designed correctly, adding a label to PR will create a new deployment. This means that we can easily choose what and when to deploy while looking through pull requests and it enables easy rollback if the new deployment fails. 

**Changes:**
1. Modified the settings.py file to use an environment variable to enable or disable debug mode. This prevents debug mode from being set in the deployment environment.
2. Created deploy.yml to automate deployment.
3. Added django.config to the ebextentions directory to configure the project for deployment.