### PR TITLE
Handle modifications to journal entries, use permissions

### DIFF
--- a/journal/permissions.py
+++ b/journal/permissions.py
@@ -1,0 +1,11 @@
+from rest_framework import permissions
+from django.shortcuts import get_object_or_404
+from .models import UserFoodJournalEntry
+
+
+class IsJournalEntryOwner(permissions.BasePermission):
+    def has_permission(self, request, view):
+        entry: UserFoodJournalEntry = get_object_or_404(
+            UserFoodJournalEntry, id=view.kwargs.get("id", None)
+        )
+        return entry.user == request.user

--- a/journal/serializers.py
+++ b/journal/serializers.py
@@ -1,16 +1,21 @@
 from rest_framework import serializers
 from .models import UserFoodJournalEntry
+from foods.serializers import AbridgedBrandedFoodSerializer
 
 
 class UserFoodJournalEntrySerializer(serializers.ModelSerializer):
+    id = serializers.IntegerField(required=False)
+    food = AbridgedBrandedFoodSerializer()
+
     class Meta:
         model = UserFoodJournalEntry
-        fields = "__all__"
+        fields = ["id", "user", "date", "amount_consumed_grams", "food"]
 
 
 class UserFoodJournalEntryDTOSerializer(serializers.Serializer):
     fdc_id = serializers.IntegerField()
     amount_consumed_grams = serializers.FloatField()
+    date = serializers.DateField(required=False)
 
 
 class UserFoodJournalEntryListSerializer(serializers.Serializer):

--- a/journal/urls.py
+++ b/journal/urls.py
@@ -3,6 +3,7 @@ from . import views
 
 urlpatterns = [
     path("dashboard/", views.UserDashboardView.as_view()),
+    path("<int:id>", views.UserFoodJournalEntryView.as_view()),
     path("entries/", views.UserFoodJournalEntriesView.as_view()),
     path("entries/create/", views.CreateUserFoodJournalEntryView.as_view()),
 ]

--- a/journal/views.py
+++ b/journal/views.py
@@ -64,7 +64,7 @@ class CreateUserFoodJournalEntryView(APIView):
 
 
 class UserFoodJournalEntryView(APIView):
-    permission_classes = [IsJournalEntryOwner]
+    permission_classes = [permissions.IsAuthenticated & IsJournalEntryOwner]
 
     @extend_schema(
         responses={

--- a/quatro/settings.py
+++ b/quatro/settings.py
@@ -154,4 +154,8 @@ SPECTACULAR_SETTINGS = {
 
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.BasicAuthentication",
+        "rest_framework.authentication.TokenAuthentication",
+    ],
 }


### PR DESCRIPTION
**Summary:**
Implemented get, put, and delete for the food journal endpoint. This allows a user to view, modify, or delete entries from their journal. Also created the IsJournalEntryOwner permission class which requires that the user requesting or modifying an entry is the owner of that entry. If the permission check fails, a 403 response is sent to the client.